### PR TITLE
feat: configurable increments

### DIFF
--- a/app/src/main/java/net/multun/gamecounter/DefaultSettings.kt
+++ b/app/src/main/java/net/multun/gamecounter/DefaultSettings.kt
@@ -1,0 +1,6 @@
+package net.multun.gamecounter
+
+object DefaultSettings {
+    val DEFAULT_SMALL_STEP = 1
+    val DEFAULT_LARGE_STEP = 10
+}

--- a/app/src/main/java/net/multun/gamecounter/store/GameRepository.kt
+++ b/app/src/main/java/net/multun/gamecounter/store/GameRepository.kt
@@ -35,6 +35,8 @@ data class Counter(
     val id: CounterId,
     val defaultValue: Int,
     val name: String,
+    val step: Int,
+    val largeStep: Int,
 )
 
 data class Player(
@@ -72,6 +74,8 @@ class GameRepository @Inject constructor(private val appStateStore: GameStore) {
                     id = CounterId(protoCounter.id),
                     defaultValue = protoCounter.defaultValue,
                     name = protoCounter.name,
+                    step = protoCounter.step,
+                    largeStep = protoCounter.largeStep,
                 )
             }.toPersistentList(),
         )
@@ -92,7 +96,7 @@ class GameRepository @Inject constructor(private val appStateStore: GameStore) {
         }
     }
 
-    suspend fun addCounter(defaultValue: Int, name: String): CounterId {
+    suspend fun addCounter(defaultValue: Int, name: String, step: Int, largeStep: Int): CounterId {
         var counterId = 0
         appStateStore.updateData { oldState ->
             // allocate an ID
@@ -105,6 +109,8 @@ class GameRepository @Inject constructor(private val appStateStore: GameStore) {
                     this.id = counterId
                     this.defaultValue = defaultValue
                     this.name = name
+                    this.step = step
+                    this.largeStep = largeStep
                 })
 
                 // update all players to add the counter
@@ -222,7 +228,7 @@ class GameRepository @Inject constructor(private val appStateStore: GameStore) {
         }
     }
 
-    suspend fun updateCounter(counterId: CounterId, name: String, defaultValue: Int) {
+    suspend fun updateCounter(counterId: CounterId, name: String, defaultValue: Int, step: Int, largeStep: Int) {
         appStateStore.updateData { oldState ->
             val counterIndex = oldState.getCounterIndex(counterId)
             if (counterIndex == -1)
@@ -231,6 +237,8 @@ class GameRepository @Inject constructor(private val appStateStore: GameStore) {
             val newCounter = oldState.getCounter(counterIndex).copy {
                 this.name = name
                 this.defaultValue = defaultValue
+                this.step = step
+                this.largeStep = largeStep
             }
             val newState = oldState.toBuilder()
             newState.setCounter(counterIndex, newCounter)

--- a/app/src/main/java/net/multun/gamecounter/store/GameStore.kt
+++ b/app/src/main/java/net/multun/gamecounter/store/GameStore.kt
@@ -28,25 +28,6 @@ import net.multun.gamecounter.proto.counter
 
 typealias GameStore = DataStore<ProtoGame.Game>
 
-private object GameMigration : DataMigration<ProtoGame.Game> {
-    override suspend fun shouldMigrate(currentData: ProtoGame.Game): Boolean =
-        currentData.counterList.any { it.step == 0 || it.largeStep == 0 }
-
-    override suspend fun migrate(currentData: ProtoGame.Game): ProtoGame.Game =
-        currentData.copy {
-            val updatedCounters = counter.map { c ->
-                c.copy {
-                    if (step == 0) step = 1
-                    if (largeStep == 0) largeStep = 10
-                }
-            }
-            counter.clear()
-            counter.addAll(updatedCounters)
-        }
-
-    override suspend fun cleanUp() {}
-}
-
 @Module
 @InstallIn(SingletonComponent::class)
 object GameStoreProvider {
@@ -60,7 +41,7 @@ object GameStoreProvider {
         DataStoreFactory.create(
             serializer = GameSerializer,
             scope = CoroutineScope(scope.coroutineContext + ioDispatcher),
-            migrations = listOf(GameMigration),
+            migrations = listOf(),
         ) {
             context.dataStoreFile("game.pb")
         }

--- a/app/src/main/java/net/multun/gamecounter/store/NewGameRepository.kt
+++ b/app/src/main/java/net/multun/gamecounter/store/NewGameRepository.kt
@@ -23,6 +23,8 @@ class NewGameRepository @Inject constructor(private val appStateStore: NewGameSt
                     id = CounterId(protoCounter.id),
                     defaultValue = protoCounter.defaultValue,
                     name = protoCounter.name,
+                    step = protoCounter.step,
+                    largeStep = protoCounter.largeStep,
                 )
             }.toPersistentList(),
         )
@@ -36,7 +38,7 @@ class NewGameRepository @Inject constructor(private val appStateStore: NewGameSt
         }
     }
 
-    suspend fun addCounter(defaultValue: Int, name: String): CounterId {
+    suspend fun addCounter(defaultValue: Int, name: String, step: Int, largeStep: Int): CounterId {
         var counterId = 0
         appStateStore.updateData { oldState ->
             // allocate an ID
@@ -49,6 +51,8 @@ class NewGameRepository @Inject constructor(private val appStateStore: NewGameSt
                     this.id = counterId
                     this.defaultValue = defaultValue
                     this.name = name
+                    this.step = step
+                    this.largeStep = largeStep
                 })
             }
         }
@@ -66,7 +70,7 @@ class NewGameRepository @Inject constructor(private val appStateStore: NewGameSt
         }
     }
 
-    suspend fun updateCounter(counterId: CounterId, name: String, defaultValue: Int) {
+    suspend fun updateCounter(counterId: CounterId, name: String, defaultValue: Int, step: Int, largeStep: Int) {
         appStateStore.updateData { oldState ->
             val counterIndex = oldState.getCounterIndex(counterId)
             if (counterIndex == -1)
@@ -75,6 +79,8 @@ class NewGameRepository @Inject constructor(private val appStateStore: NewGameSt
             val newCounter = oldState.getCounter(counterIndex).copy {
                 this.name = name
                 this.defaultValue = defaultValue
+                this.step = step
+                this.largeStep = largeStep
             }
             val newState = oldState.toBuilder()
             newState.setCounter(counterIndex, newCounter)

--- a/app/src/main/java/net/multun/gamecounter/store/NewGameRepository.kt
+++ b/app/src/main/java/net/multun/gamecounter/store/NewGameRepository.kt
@@ -23,8 +23,8 @@ class NewGameRepository @Inject constructor(private val appStateStore: NewGameSt
                     id = CounterId(protoCounter.id),
                     defaultValue = protoCounter.defaultValue,
                     name = protoCounter.name,
-                    step = protoCounter.step,
-                    largeStep = protoCounter.largeStep,
+                    smallStep = if (protoCounter.step == 0) null else protoCounter.step,
+                    largeStep = if (protoCounter.largeStep == 0) null else protoCounter.largeStep,
                 )
             }.toPersistentList(),
         )
@@ -38,7 +38,7 @@ class NewGameRepository @Inject constructor(private val appStateStore: NewGameSt
         }
     }
 
-    suspend fun addCounter(defaultValue: Int, name: String, step: Int, largeStep: Int): CounterId {
+    suspend fun addCounter(defaultValue: Int, name: String, step: Int?, largeStep: Int?): CounterId {
         var counterId = 0
         appStateStore.updateData { oldState ->
             // allocate an ID
@@ -51,8 +51,8 @@ class NewGameRepository @Inject constructor(private val appStateStore: NewGameSt
                     this.id = counterId
                     this.defaultValue = defaultValue
                     this.name = name
-                    this.step = step
-                    this.largeStep = largeStep
+                    this.step = step ?: 0
+                    this.largeStep = largeStep ?: 0
                 })
             }
         }
@@ -70,7 +70,7 @@ class NewGameRepository @Inject constructor(private val appStateStore: NewGameSt
         }
     }
 
-    suspend fun updateCounter(counterId: CounterId, name: String, defaultValue: Int, step: Int, largeStep: Int) {
+    suspend fun updateCounter(counterId: CounterId, name: String, defaultValue: Int, step: Int?, largeStep: Int?) {
         appStateStore.updateData { oldState ->
             val counterIndex = oldState.getCounterIndex(counterId)
             if (counterIndex == -1)
@@ -79,8 +79,8 @@ class NewGameRepository @Inject constructor(private val appStateStore: NewGameSt
             val newCounter = oldState.getCounter(counterIndex).copy {
                 this.name = name
                 this.defaultValue = defaultValue
-                this.step = step
-                this.largeStep = largeStep
+                this.step = step ?: 0
+                this.largeStep = largeStep ?: 0
             }
             val newState = oldState.toBuilder()
             newState.setCounter(counterIndex, newCounter)

--- a/app/src/main/java/net/multun/gamecounter/store/NewGameStore.kt
+++ b/app/src/main/java/net/multun/gamecounter/store/NewGameStore.kt
@@ -31,25 +31,6 @@ import net.multun.gamecounter.proto.counter
 
 typealias NewGameStore = DataStore<ProtoNewGame.NewGame>
 
-private object NewGameMigration : DataMigration<ProtoNewGame.NewGame> {
-    override suspend fun shouldMigrate(currentData: ProtoNewGame.NewGame): Boolean =
-        currentData.counterList.any { it.step == 0 || it.largeStep == 0 }
-
-    override suspend fun migrate(currentData: ProtoNewGame.NewGame): ProtoNewGame.NewGame =
-        currentData.copy {
-            val updatedCounters = counter.map { c ->
-                c.copy {
-                    if (step == 0) step = 1
-                    if (largeStep == 0) largeStep = 10
-                }
-            }
-            counter.clear()
-            counter.addAll(updatedCounters)
-        }
-
-    override suspend fun cleanUp() {}
-}
-
 @Module
 @InstallIn(SingletonComponent::class)
 object NewGameStoreProvider {
@@ -63,7 +44,7 @@ object NewGameStoreProvider {
         DataStoreFactory.create(
             serializer = NewGameSerializer,
             scope = CoroutineScope(scope.coroutineContext + ioDispatcher),
-            migrations = listOf(NewGameMigration),
+            migrations = listOf(),
         ) {
             context.dataStoreFile("new_game.pb")
         }
@@ -74,8 +55,6 @@ fun makeDefaultCounter(): ProtoGame.Counter {
         this.id = 0
         this.name = "hp"
         this.defaultValue = 100
-        this.step = 1
-        this.largeStep = 10
     }
 }
 

--- a/app/src/main/java/net/multun/gamecounter/store/NewGameStore.kt
+++ b/app/src/main/java/net/multun/gamecounter/store/NewGameStore.kt
@@ -51,6 +51,8 @@ fun makeDefaultCounter(): ProtoGame.Counter {
         this.id = 0
         this.name = "hp"
         this.defaultValue = 100
+        this.step = 1
+        this.largeStep = 10
     }
 }
 

--- a/app/src/main/java/net/multun/gamecounter/ui/board/BoardScreen.kt
+++ b/app/src/main/java/net/multun/gamecounter/ui/board/BoardScreen.kt
@@ -144,7 +144,7 @@ private fun Board(boardUI: BoardUI, viewModel: BoardViewModel, navController: Na
                     player,
                     onSetColor = remember { { color -> viewModel.setPlayerColor(player.id, color) } },
                     onDelete = remember { { modalState = ModalConfirmRemovePlayer(player.id) } },
-                    onUpdateCounter = remember { { counterId, delta -> viewModel.updateCounter(player.id, counterId, delta) } },
+                    onUpdateCounter = remember { { counterId, counterUpdate -> viewModel.updateCounter(player.id, counterId, counterUpdate) } },
                     onSelectCounter = remember { { counterId -> viewModel.selectCounter(player.id, counterId) } },
                     onEditName = remember { { modalState = ModalEditPlayerName(player.id) } },
                     modifier = slotModifier.wrapContentSize(),
@@ -206,10 +206,10 @@ private fun Board(boardUI: BoardUI, viewModel: BoardViewModel, navController: Na
                             // the default size is huge due to minimumInteractiveComponentSize
                             modifier = Modifier.size(30.dp),
                             checked = boardUI.alwaysUprightMode,
-                            onCheckedChange = { viewModel.setUlwaysUprightMode(it) }
+                            onCheckedChange = { viewModel.setAlwaysUprightMode(it) }
                         )
                     }, stringResource(R.string.always_up_tiles)) {
-                        viewModel.setUlwaysUprightMode(!boardUI.alwaysUprightMode)
+                        viewModel.setAlwaysUprightMode(!boardUI.alwaysUprightMode)
                     }
 
                     SettingsItem(Icons.Filled.Replay, stringResource(R.string.reset_game)) {

--- a/app/src/main/java/net/multun/gamecounter/ui/board/BoardViewModel.kt
+++ b/app/src/main/java/net/multun/gamecounter/ui/board/BoardViewModel.kt
@@ -67,6 +67,8 @@ data class CounterUIState(
     val name: String,
     val value: Int,
     val combo: Int,
+    val step: Int,
+    val largeStep: Int,
 )
 
 data class PlayerSettingsUIState(
@@ -166,7 +168,9 @@ class BoardViewModel @Inject constructor(private val repository: GameRepository)
                                 id = it.id,
                                 name = it.name,
                                 value = player.counters[it.id]!!,
-                                combo = combos[ComboCounterId(player.id, it.id)] ?: 0
+                                combo = combos[ComboCounterId(player.id, it.id)] ?: 0,
+                                step = it.step,
+                                largeStep = it.largeStep,
                             )
                         },
                         selectedCounter = player.selectedCounter ?: appState.counters[0].id

--- a/app/src/main/java/net/multun/gamecounter/ui/board/BoardViewModel.kt
+++ b/app/src/main/java/net/multun/gamecounter/ui/board/BoardViewModel.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import net.multun.gamecounter.store.CounterId
+import net.multun.gamecounter.store.CounterUpdate
 import net.multun.gamecounter.store.PlayerId
 import net.multun.gamecounter.store.GameRepository
 import javax.inject.Inject
@@ -67,8 +68,6 @@ data class CounterUIState(
     val name: String,
     val value: Int,
     val combo: Int,
-    val step: Int,
-    val largeStep: Int,
 )
 
 data class PlayerSettingsUIState(
@@ -169,8 +168,6 @@ class BoardViewModel @Inject constructor(private val repository: GameRepository)
                                 name = it.name,
                                 value = player.counters[it.id]!!,
                                 combo = combos[ComboCounterId(player.id, it.id)] ?: 0,
-                                step = it.step,
-                                largeStep = it.largeStep,
                             )
                         },
                         selectedCounter = player.selectedCounter ?: appState.counters[0].id
@@ -214,16 +211,16 @@ class BoardViewModel @Inject constructor(private val repository: GameRepository)
         }
     }
 
-    fun setUlwaysUprightMode(alwaysUprightMode: Boolean) {
+    fun setAlwaysUprightMode(alwaysUprightMode: Boolean) {
         viewModelScope.launch {
             repository.setAlwaysUprightMode(alwaysUprightMode)
         }
     }
 
-    fun updateCounter(playerId: PlayerId, counterId: CounterId, counterDelta: Int) {
+    fun updateCounter(playerId: PlayerId, counterId: CounterId, counterUpdate: CounterUpdate) {
         viewModelScope.launch {
             // update the counter
-            repository.updatePlayerCounter(playerId, counterId, counterDelta)
+            val counterDelta = repository.updatePlayerCounter(playerId, counterId, counterUpdate)
 
             val counterKey = ComboCounterId(playerId, counterId)
             // update the combo counter

--- a/app/src/main/java/net/multun/gamecounter/ui/board/CounterUpdateButton.kt
+++ b/app/src/main/java/net/multun/gamecounter/ui/board/CounterUpdateButton.kt
@@ -26,10 +26,10 @@ sealed interface CounterUpdateEvent
 data object SmallCounterUpdate : CounterUpdateEvent
 data object BigCounterUpdate : CounterUpdateEvent
 
-fun CounterUpdateEvent.stepSize(): Int {
+fun CounterUpdateEvent.stepSize(step: Int, largeStep: Int): Int {
     return when (this) {
-        BigCounterUpdate -> 10
-        SmallCounterUpdate -> 1
+        BigCounterUpdate -> largeStep
+        SmallCounterUpdate -> step
     }
 }
 

--- a/app/src/main/java/net/multun/gamecounter/ui/board/CounterUpdateButton.kt
+++ b/app/src/main/java/net/multun/gamecounter/ui/board/CounterUpdateButton.kt
@@ -3,7 +3,6 @@ package net.multun.gamecounter.ui.board
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
-import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.IconButton
@@ -22,22 +21,13 @@ import kotlin.time.Duration.Companion.milliseconds
 private val INITIAL_DELAY = 700.milliseconds
 private val BUMP_DELAY = 500.milliseconds
 
-sealed interface CounterUpdateEvent
-data object SmallCounterUpdate : CounterUpdateEvent
-data object BigCounterUpdate : CounterUpdateEvent
-
-fun CounterUpdateEvent.stepSize(step: Int, largeStep: Int): Int {
-    return when (this) {
-        BigCounterUpdate -> largeStep
-        SmallCounterUpdate -> step
-    }
-}
 
 class UpdateButtonState {
     val interactionSource = MutableInteractionSource()
 
+    // on event, returns whether the button was long pressed
     @Composable
-    fun WatchEvents(onEvent: (CounterUpdateEvent) -> Unit) {
+    fun WatchEvents(onEvent: (Boolean) -> Unit) {
         var longPressed by remember(interactionSource) { mutableStateOf(false) }
         var isPressed by remember(interactionSource) { mutableStateOf(false) }
 
@@ -59,7 +49,8 @@ class UpdateButtonState {
                     if (longPressed) {
                         longPressed = false
                     } else {
-                        onEvent(SmallCounterUpdate)
+                        // short press
+                        onEvent(false)
                     }
                 }
                 isPressed = pressInteractions.isNotEmpty()
@@ -72,7 +63,8 @@ class UpdateButtonState {
             delay(INITIAL_DELAY)
             longPressed = true
             while (true) {
-                onEvent(BigCounterUpdate)
+                // long press
+                onEvent(true)
                 delay(BUMP_DELAY)
             }
         }

--- a/app/src/main/java/net/multun/gamecounter/ui/board/PlayerCard.kt
+++ b/app/src/main/java/net/multun/gamecounter/ui/board/PlayerCard.kt
@@ -44,6 +44,7 @@ import com.sd.lib.compose.wheel_picker.rememberFWheelPickerState
 import net.multun.gamecounter.PaletteColor
 import net.multun.gamecounter.R
 import net.multun.gamecounter.store.CounterId
+import net.multun.gamecounter.store.CounterUpdate
 import net.multun.gamecounter.store.PlayerId
 import net.multun.gamecounter.toDisplayColor
 
@@ -105,7 +106,7 @@ fun Player(
     onEditName: () -> Unit,
     onDelete: () -> Unit,
     onMove: (Int) -> Unit,
-    onUpdateCounter: (CounterId, Int) -> Unit,
+    onUpdateCounter: (CounterId, CounterUpdate) -> Unit,
     onSelectCounter: (CounterId) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -284,7 +285,7 @@ fun PlayerCardPreview() {
             color = PaletteColor.Blue.color,
             name = "Alice",
             counters = listOf(
-                CounterUIState(CounterId(0), "test", 100, 1, 1, 10)
+                CounterUIState(CounterId(0), "test", 100, 1)
             ),
             selectedCounter = CounterId(0),
         ),

--- a/app/src/main/java/net/multun/gamecounter/ui/board/PlayerCard.kt
+++ b/app/src/main/java/net/multun/gamecounter/ui/board/PlayerCard.kt
@@ -284,7 +284,7 @@ fun PlayerCardPreview() {
             color = PaletteColor.Blue.color,
             name = "Alice",
             counters = listOf(
-                CounterUIState(CounterId(0), "test", 100, 1)
+                CounterUIState(CounterId(0), "test", 100, 1, 1, 10)
             ),
             selectedCounter = CounterId(0),
         ),

--- a/app/src/main/java/net/multun/gamecounter/ui/board/PlayerCounter.kt
+++ b/app/src/main/java/net/multun/gamecounter/ui/board/PlayerCounter.kt
@@ -51,6 +51,8 @@ import com.sd.lib.compose.wheel_picker.FHorizontalWheelPicker
 import com.sd.lib.compose.wheel_picker.rememberFWheelPickerState
 import net.multun.gamecounter.R
 import net.multun.gamecounter.store.CounterId
+import net.multun.gamecounter.store.CounterUpdate
+import net.multun.gamecounter.store.FixedUpdate
 
 
 @Composable
@@ -163,7 +165,7 @@ fun PlayerTopRow(
 @Composable
 fun PlayerCounter(
     player: CounterCardUIState,
-    onUpdateCounter: (CounterId, Int) -> Unit,
+    onUpdateCounter: (CounterId, CounterUpdate) -> Unit,
     onSelectCounter: (CounterId) -> Unit,
     onEditCounter: () -> Unit,
     onEditColor: () -> Unit,
@@ -176,8 +178,8 @@ fun PlayerCounter(
         val minusButtonState = remember { UpdateButtonState() }
         val plusButtonState = remember { UpdateButtonState() }
 
-        minusButtonState.WatchEvents(onEvent = remember(player.selectedCounter, counter.id, counter.step, counter.largeStep) { { onUpdateCounter(player.selectedCounter, -it.stepSize(counter.step, counter.largeStep)) } })
-        plusButtonState.WatchEvents(onEvent = remember(player.selectedCounter, counter.id, counter.step, counter.largeStep) { { onUpdateCounter(player.selectedCounter, it.stepSize(counter.step, counter.largeStep)) } })
+        minusButtonState.WatchEvents(onEvent = remember(player.selectedCounter, counter.id) { { longPress -> onUpdateCounter(player.selectedCounter, FixedUpdate(longPress, -1)) } })
+        plusButtonState.WatchEvents(onEvent = remember(player.selectedCounter, counter.id) { { longPress -> onUpdateCounter(player.selectedCounter, FixedUpdate(longPress, 1)) } })
 
         // minus
         CounterUpdateButton(minusButtonState, modifier = Modifier.layoutId("decrButton")) {

--- a/app/src/main/java/net/multun/gamecounter/ui/board/PlayerCounter.kt
+++ b/app/src/main/java/net/multun/gamecounter/ui/board/PlayerCounter.kt
@@ -176,8 +176,8 @@ fun PlayerCounter(
         val minusButtonState = remember { UpdateButtonState() }
         val plusButtonState = remember { UpdateButtonState() }
 
-        minusButtonState.WatchEvents(onEvent = remember(player.selectedCounter) { { onUpdateCounter(player.selectedCounter, -it.stepSize()) } })
-        plusButtonState.WatchEvents(onEvent = remember(player.selectedCounter) { { onUpdateCounter(player.selectedCounter, it.stepSize()) } })
+        minusButtonState.WatchEvents(onEvent = remember(player.selectedCounter, counter.id, counter.step, counter.largeStep) { { onUpdateCounter(player.selectedCounter, -it.stepSize(counter.step, counter.largeStep)) } })
+        plusButtonState.WatchEvents(onEvent = remember(player.selectedCounter, counter.id, counter.step, counter.largeStep) { { onUpdateCounter(player.selectedCounter, it.stepSize(counter.step, counter.largeStep)) } })
 
         // minus
         CounterUpdateButton(minusButtonState, modifier = Modifier.layoutId("decrButton")) {

--- a/app/src/main/java/net/multun/gamecounter/ui/board/PlayerCounterUpdateMenu.kt
+++ b/app/src/main/java/net/multun/gamecounter/ui/board/PlayerCounterUpdateMenu.kt
@@ -21,11 +21,12 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.em
 import com.sd.lib.compose.wheel_picker.FWheelPickerState
 import com.sd.lib.compose.wheel_picker.rememberFWheelPickerState
 import net.multun.gamecounter.R
 import net.multun.gamecounter.store.CounterId
+import net.multun.gamecounter.store.CounterUpdate
+import net.multun.gamecounter.store.CustomUpdate
 import kotlin.math.max
 
 @Composable
@@ -33,7 +34,7 @@ fun PlayerCounterUpdateMenu(
     signState: FWheelPickerState,
     player: CounterCardUIState,
     counterScale: FontScale,
-    onUpdateCounter: (CounterId, Int) -> Unit,
+    onUpdateCounter: (CounterId, CounterUpdate) -> Unit,
     onClose: () -> Unit
 ) {
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -97,7 +98,7 @@ fun PlayerCounterUpdateMenu(
             }
             if ((signState.currentIndex % 2) != 0)
                 total = -total
-            onUpdateCounter(player.selectedCounter, total)
+            onUpdateCounter(player.selectedCounter, CustomUpdate(total))
             onClose()
         }, Modifier.align(Alignment.BottomEnd)) {
             Icon(Icons.Filled.Check, null)

--- a/app/src/main/java/net/multun/gamecounter/ui/counter_settings/GameCounterSettingsViewModel.kt
+++ b/app/src/main/java/net/multun/gamecounter/ui/counter_settings/GameCounterSettingsViewModel.kt
@@ -19,7 +19,7 @@ import javax.inject.Inject
 class GameCounterSettingsViewModel @Inject constructor(private val repository: GameRepository) : ViewModel() {
     val settingsUIState = repository.appState.map { appState ->
         appState.counters.map {
-            CounterSettingsUIState(it.id, it.name, it.defaultValue, it.step, it.largeStep)
+            CounterSettingsUIState(it.id, it.name, it.defaultValue, it.smallStep, it.largeStep)
         }.toImmutableList()
     }.stateIn(
         scope = viewModelScope,
@@ -27,7 +27,7 @@ class GameCounterSettingsViewModel @Inject constructor(private val repository: G
         initialValue = persistentListOf(),
     )
 
-    fun addCounter(counterName: String, defaultValue: Int, step: Int, largeStep: Int) {
+    fun addCounter(counterName: String, defaultValue: Int, step: Int?, largeStep: Int?) {
         viewModelScope.launch {
             repository.addCounter(defaultValue, counterName, step, largeStep)
         }
@@ -51,7 +51,7 @@ class GameCounterSettingsViewModel @Inject constructor(private val repository: G
         }
     }
 
-    fun updateCounter(counterId: CounterId, name: String, defaultVal: Int, step: Int, largeStep: Int) {
+    fun updateCounter(counterId: CounterId, name: String, defaultVal: Int, step: Int?, largeStep: Int?) {
         viewModelScope.launch {
             repository.updateCounter(counterId, name, defaultVal, step, largeStep)
         }

--- a/app/src/main/java/net/multun/gamecounter/ui/counter_settings/GameCounterSettingsViewModel.kt
+++ b/app/src/main/java/net/multun/gamecounter/ui/counter_settings/GameCounterSettingsViewModel.kt
@@ -19,7 +19,7 @@ import javax.inject.Inject
 class GameCounterSettingsViewModel @Inject constructor(private val repository: GameRepository) : ViewModel() {
     val settingsUIState = repository.appState.map { appState ->
         appState.counters.map {
-            CounterSettingsUIState(it.id, it.name, it.defaultValue)
+            CounterSettingsUIState(it.id, it.name, it.defaultValue, it.step, it.largeStep)
         }.toImmutableList()
     }.stateIn(
         scope = viewModelScope,
@@ -27,9 +27,9 @@ class GameCounterSettingsViewModel @Inject constructor(private val repository: G
         initialValue = persistentListOf(),
     )
 
-    fun addCounter(counterName: String, defaultValue: Int) {
+    fun addCounter(counterName: String, defaultValue: Int, step: Int, largeStep: Int) {
         viewModelScope.launch {
-            repository.addCounter(defaultValue, counterName)
+            repository.addCounter(defaultValue, counterName, step, largeStep)
         }
     }
 
@@ -51,9 +51,9 @@ class GameCounterSettingsViewModel @Inject constructor(private val repository: G
         }
     }
 
-    fun updateCounter(counterId: CounterId, name: String, defaultVal: Int) {
+    fun updateCounter(counterId: CounterId, name: String, defaultVal: Int, step: Int, largeStep: Int) {
         viewModelScope.launch {
-            repository.updateCounter(counterId, name, defaultVal)
+            repository.updateCounter(counterId, name, defaultVal, step, largeStep)
         }
     }
 }

--- a/app/src/main/java/net/multun/gamecounter/ui/new_game_menu/NewGameMenu.kt
+++ b/app/src/main/java/net/multun/gamecounter/ui/new_game_menu/NewGameMenu.kt
@@ -157,8 +157,8 @@ fun NewGameMenu(viewModel: NewGameViewModel, navController: NavController, modif
         CounterSettingsDialog(
             curDialog,
             onDelete = remember { { viewModel.deleteCounter(it) } },
-            onAddCounter = remember { { name, defaultVal -> viewModel.addCounter(name, defaultVal) } },
-            onUpdateCounter = remember { { id, name, defaultVal -> viewModel.updateCounter(id, name, defaultVal) } },
+            onAddCounter = remember { { name, defaultVal, step, largeStep -> viewModel.addCounter(name, defaultVal, step, largeStep) } },
+            onUpdateCounter = remember { { id, name, defaultVal, step, largeStep -> viewModel.updateCounter(id, name, defaultVal, step, largeStep) } },
             onClearDialog = remember { { dialog = null } },
         )
     }

--- a/app/src/main/java/net/multun/gamecounter/ui/new_game_menu/NewGameViewModel.kt
+++ b/app/src/main/java/net/multun/gamecounter/ui/new_game_menu/NewGameViewModel.kt
@@ -57,6 +57,8 @@ class NewGameViewModel @Inject constructor(
                         this.id = it.id.value
                         this.name = it.name
                         this.defaultValue = it.defaultValue
+                        this.step = it.step
+                        this.largeStep = it.largeStep
                     }
                 }
             currentGame.startGame(
@@ -68,7 +70,7 @@ class NewGameViewModel @Inject constructor(
 
     val counterSettingsUI = newGame.appState.map { appState ->
         appState.counters.map {
-            CounterSettingsUIState(it.id, it.name, it.defaultValue)
+            CounterSettingsUIState(it.id, it.name, it.defaultValue, it.step, it.largeStep)
         }.toImmutableList()
     }.stateIn(
         scope = viewModelScope,
@@ -76,9 +78,9 @@ class NewGameViewModel @Inject constructor(
         initialValue = persistentListOf(),
     )
 
-    fun addCounter(counterName: String, defaultValue: Int) {
+    fun addCounter(counterName: String, defaultValue: Int, step: Int, largeStep: Int) {
         viewModelScope.launch {
-            newGame.addCounter(defaultValue, counterName)
+            newGame.addCounter(defaultValue, counterName, step, largeStep)
         }
     }
 
@@ -100,9 +102,9 @@ class NewGameViewModel @Inject constructor(
         }
     }
 
-    fun updateCounter(counterId: CounterId, name: String, defaultVal: Int) {
+    fun updateCounter(counterId: CounterId, name: String, defaultVal: Int, step: Int, largeStep: Int) {
         viewModelScope.launch {
-            newGame.updateCounter(counterId, name, defaultVal)
+            newGame.updateCounter(counterId, name, defaultVal, step, largeStep)
         }
     }
 }

--- a/app/src/main/java/net/multun/gamecounter/ui/new_game_menu/NewGameViewModel.kt
+++ b/app/src/main/java/net/multun/gamecounter/ui/new_game_menu/NewGameViewModel.kt
@@ -57,8 +57,8 @@ class NewGameViewModel @Inject constructor(
                         this.id = it.id.value
                         this.name = it.name
                         this.defaultValue = it.defaultValue
-                        this.step = it.step
-                        this.largeStep = it.largeStep
+                        this.step = it.smallStep ?: 0
+                        this.largeStep = it.largeStep ?: 0
                     }
                 }
             currentGame.startGame(
@@ -70,7 +70,7 @@ class NewGameViewModel @Inject constructor(
 
     val counterSettingsUI = newGame.appState.map { appState ->
         appState.counters.map {
-            CounterSettingsUIState(it.id, it.name, it.defaultValue, it.step, it.largeStep)
+            CounterSettingsUIState(it.id, it.name, it.defaultValue, it.smallStep, it.largeStep)
         }.toImmutableList()
     }.stateIn(
         scope = viewModelScope,
@@ -78,7 +78,7 @@ class NewGameViewModel @Inject constructor(
         initialValue = persistentListOf(),
     )
 
-    fun addCounter(counterName: String, defaultValue: Int, step: Int, largeStep: Int) {
+    fun addCounter(counterName: String, defaultValue: Int, step: Int?, largeStep: Int?) {
         viewModelScope.launch {
             newGame.addCounter(defaultValue, counterName, step, largeStep)
         }
@@ -102,7 +102,7 @@ class NewGameViewModel @Inject constructor(
         }
     }
 
-    fun updateCounter(counterId: CounterId, name: String, defaultVal: Int, step: Int, largeStep: Int) {
+    fun updateCounter(counterId: CounterId, name: String, defaultVal: Int, step: Int?, largeStep: Int?) {
         viewModelScope.launch {
             newGame.updateCounter(counterId, name, defaultVal, step, largeStep)
         }

--- a/app/src/main/proto/game.proto
+++ b/app/src/main/proto/game.proto
@@ -15,6 +15,8 @@ message Counter {
   int32 id = 1;
   string name = 2;
   int32 defaultValue = 3;
+  int32 step = 4;
+  int32 largeStep = 5;
 }
 
 message Game {

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -14,6 +14,7 @@
     <string name="cancel">Cancelar</string>
     <string name="name">Nombre</string>
     <string name="counter_default_value">Valor predeterminado</string>
+    <string name="counter_big_step">"Gran incremento "</string>
     <string name="previous_screen">Pantalla anterior</string>
     <string name="player_settings">Ajustes de jugador</string>
     <string name="increase_counter">Aumentar contador</string>
@@ -48,4 +49,5 @@
     <string name="players">Jugadores</string>
     <string name="counters">Contadores</string>
     <string name="add_counter">Añadir contador</string>
+    <string name="counter_step">"Pequeño incremento "</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -14,6 +14,7 @@
     <string name="cancel">Annuler</string>
     <string name="name">Nom</string>
     <string name="counter_default_value">Valeur initiale</string>
+    <string name="counter_big_step">Grand incrément</string>
     <string name="previous_screen">Page précédente</string>
     <string name="player_settings">Paramètres du joueur</string>
     <string name="increase_counter">Augmenter la valeur</string>
@@ -48,4 +49,5 @@
     <string name="players">Joueurs</string>
     <string name="counters">Compteurs</string>
     <string name="add_counter">Ajouter un compteur</string>
+    <string name="counter_step">Petit incrément</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -13,8 +13,9 @@
         <string name="confirm">Conferma</string>  
         <string name="cancel">Annulla</string>  
         <string name="name">Nome</string>  
-        <string name="counter_default_value">Valore predefinito</string>  
-        <string name="previous_screen">Schermata precedente</string>  
+        <string name="counter_default_value">Valore predefinito</string>
+        <string name="counter_big_step">Grande incremento</string>
+        <string name="previous_screen">Schermata precedente</string>
         <string name="player_settings">Impostazioni giocatore</string>  
         <string name="increase_counter">Aumenta contatore</string>  
         <string name="decrease_counter">Diminuisci contatore</string>  
@@ -47,5 +48,6 @@
         <string name="confirm_remove_player">Sei sicuro di voler rimuovere questo giocatore?</string>  
         <string name="players">Giocatori</string>  
         <string name="counters">Contatori</string>  
-        <string name="add_counter">Aggiungi contatore</string>  
-    </resources>
+        <string name="add_counter">Aggiungi contatore</string>
+    <string name="counter_step">"Piccolo incremento "</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,8 @@
     <string name="cancel">Cancel</string>
     <string name="name">Name</string>
     <string name="counter_default_value">Default value</string>
+    <string name="counter_step">Increment</string>
+    <string name="counter_big_step">Large increment</string>
     <string name="previous_screen">Previous screen</string>
     <string name="player_settings">Player settings</string>
     <string name="increase_counter">Increase counter</string>


### PR DESCRIPTION
As it says, configurable steps/increments for Small and Big counter updates. 
Very simple, just another config in the counter screen. 
I used the word `large` because its somewhere in the changelog but `bigStep` would work too.
Increments default to 1 and 10 to keep current behavior.

<img width="535" height="922" alt="2026-01-10_20-41-23" src="https://github.com/user-attachments/assets/0c7fd218-8334-43d0-bdfa-a4a8d6ebdd9a" />
<img width="526" height="333" alt="2026-01-10_20-41-05" src="https://github.com/user-attachments/assets/b1f8c460-1e9b-4e5c-9e48-8fffd1cab334" />
